### PR TITLE
chore: Add the keyForRelationship hook

### DIFF
--- a/addon/mixins/json-api-bagaaravel-serializer.js
+++ b/addon/mixins/json-api-bagaaravel-serializer.js
@@ -14,6 +14,11 @@ export default Mixin.create({
     return underscore(key)
   },
 
+  // Bagaaravel uses camelCase for relationship keys so no transformation is needed
+  keyForRelationship (key) {
+    return key
+  },
+
   // Bagaaravel uses the singular classified form of a model's name for "type".
   // "model-name" -> "ModelName"
   payloadKeyFromModelName (modelName) {


### PR DESCRIPTION
Since Bagaaravel camelCases relationship keys Ember Data does not need
to do any transformation